### PR TITLE
fixed: use github.com/didi/gendry in README

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -14,7 +14,7 @@ package main
 import (
     "database/sql"
     _ "github.com/go-sql-driver/mysql"
-    qb "github.com/didichuxing/gendry/builder"
+    qb "github.com/didi/gendry/builder"
 )
 
 func main() {

--- a/manager/README.md
+++ b/manager/README.md
@@ -19,7 +19,7 @@ What the manager does is providing a series of simple methods which help you set
 ```go
 
 import (
-	"github.com/didichuxing/gendry/manager"
+	"github.com/didi/gendry/manager"
 	_ "github.com/go-sql-driver/mysql"
 )
 

--- a/scanner/README.md
+++ b/scanner/README.md
@@ -6,7 +6,7 @@
 import (
     "database/sql"
     "fmt"
-    "github.com/didichuxing/gendry/scanner"
+    "github.com/didi/gendry/scanner"
 )
 
 type Person struct {


### PR DESCRIPTION
Use github.com/didi/gendry, instead of github.com/didichuxing/gendry.