### PR TITLE
Fix _limit 使用单个参数

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -95,8 +95,12 @@ func BuildSelect(table string, where map[string]interface{}, selectField []strin
 			return
 		}
 		if len(arr) != 2 {
-			err = errLimitValueLength
-			return
+			if len(arr) == 1 {
+				arr = []uint{0, arr[0]}
+			} else {
+				err = errLimitValueLength
+				return
+			}
 		}
 		begin, step := arr[0], arr[1]
 		limit = &eleLimit{

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -91,6 +91,21 @@ func TestBuildHaving(t *testing.T) {
 				err:  nil,
 			},
 		},
+		{
+			in: inStruct{
+				table: "tb",
+				where: map[string]interface{}{
+					"_limit": []uint{1},
+					"age in": []interface{}{1, 2, 3},
+				},
+				selectField: []string{"name, age"},
+			},
+			out: outStruct{
+				cond: "SELECT name, age FROM tb WHERE (age IN (?,?,?)) LIMIT 0,1",
+				vals: []interface{}{1, 2, 3},
+				err:  nil,
+			},
+		},
 	}
 	ass := assert.New(t)
 	for _, tc := range data {

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -106,6 +106,21 @@ func TestBuildHaving(t *testing.T) {
 				err:  nil,
 			},
 		},
+		{
+			in: inStruct{
+				table: "tb",
+				where: map[string]interface{}{
+					"_limit": []uint{2, 1},
+					"age in": []interface{}{1, 2, 3},
+				},
+				selectField: []string{"name, age"},
+			},
+			out: outStruct{
+				cond: "SELECT name, age FROM tb WHERE (age IN (?,?,?)) LIMIT 2,1",
+				vals: []interface{}{1, 2, 3},
+				err:  nil,
+			},
+		},
 	}
 	ass := assert.New(t)
 	for _, tc := range data {


### PR DESCRIPTION
获取一条数据的时候，好像这样使用，略显麻烦
`_limit = []uint{0,1}`

获取一条感觉这样优雅一点😀
_limit = []uint{1}