### PR TITLE
fix the bug when data is type []uint8

### DIFF
--- a/builder/utils.go
+++ b/builder/utils.go
@@ -3,6 +3,7 @@ package builder
 import (
 	"context"
 	"database/sql"
+	"strconv"
 )
 
 // AggregateQuery is a helper function to execute the aggregate query and return the result
@@ -50,6 +51,12 @@ func (r resultResolve) Int64() int64 {
 	f64, ok := r.data.(float64)
 	if ok {
 		return int64(f64)
+	}
+	u8L, ok := r.data.([]uint8)
+	if ok {
+		s := string(u8L)
+		u64, _ := strconv.ParseUint(s, 10, 0)
+		return int64(u64)
 	}
 	f32, _ := r.data.(float32)
 	return int64(f32)


### PR DESCRIPTION
#18 

I try to add some test case, but I seems like sqlmock cound not handle this case.

So, I just make the workaround handle the special case, but I wonder that the resultResolve should do something like the convertAssign  function in https://golang.org/src/database/sql/convert.go