### PR TITLE
fix bug: show different error message for in, not in, between, not between

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -14,13 +14,14 @@ var (
 	errSplitOrderBy  = errors.New(`[builder] the value of _orderby should be "fieldName direction [,fieldName direction]"`)
 	// ErrUnsupportedOperator reports there's unsupported operators in where-condition
 	ErrUnsupportedOperator       = errors.New("[builder] unsupported operator")
-	errWhereInType               = errors.New(`[builder] the value of "xxx in" must be of []interface{} type`)
 	errGroupByValueType          = errors.New(`[builder] the value of "_groupby" must be of string type`)
 	errLimitValueType            = errors.New(`[builder] the value of "_limit" must be of []uint type`)
 	errLimitValueLength          = errors.New(`[builder] the value of "_limit" must contain one or two uint elements`)
-	errEmptyINCondition          = errors.New(`[builder] the value of "in" must contain at least one element`)
 	errHavingValueType           = errors.New(`[builder] the value of "_having" must be of map[string]interface{}`)
 	errHavingUnsupportedOperator = errors.New(`[builder] "_having" contains unsupported operator`)
+
+	errWhereInterfaceSliceType = `[builder] the value of "xxx %s" must be of []interface{} type`
+	errEmptySliceCondition     = `[builder] the value of "%s" must contain at least one element`
 )
 
 type whereMapSet struct {
@@ -269,28 +270,28 @@ var op2Comparable = map[string]compareProducer{
 		return Ne(m), nil
 	},
 	opIn: func(m map[string]interface{}) (Comparable, error) {
-		wp, err := convertWhereMapToWhereMapSlice(m)
+		wp, err := convertWhereMapToWhereMapSlice(m, opIn)
 		if nil != err {
 			return nil, err
 		}
 		return In(wp), nil
 	},
 	opNotIn: func(m map[string]interface{}) (Comparable, error) {
-		wp, err := convertWhereMapToWhereMapSlice(m)
+		wp, err := convertWhereMapToWhereMapSlice(m, opNotIn)
 		if nil != err {
 			return nil, err
 		}
 		return NotIn(wp), nil
 	},
 	opBetween: func(m map[string]interface{}) (Comparable, error) {
-		wp, err := convertWhereMapToWhereMapSlice(m)
+		wp, err := convertWhereMapToWhereMapSlice(m, opBetween)
 		if nil != err {
 			return nil, err
 		}
 		return Between(wp), nil
 	},
 	opNotBetween: func(m map[string]interface{}) (Comparable, error) {
-		wp, err := convertWhereMapToWhereMapSlice(m)
+		wp, err := convertWhereMapToWhereMapSlice(m, opNotBetween)
 		if nil != err {
 			return nil, err
 		}
@@ -343,15 +344,17 @@ func buildWhereCondition(mapSet *whereMapSet) ([]Comparable, func(), error) {
 	return cpArr, release, nil
 }
 
-func convertWhereMapToWhereMapSlice(where map[string]interface{}) (map[string][]interface{}, error) {
+func convertWhereMapToWhereMapSlice(where map[string]interface{}, op string) (map[string][]interface{}, error) {
 	result := make(map[string][]interface{})
 	for key, val := range where {
 		vals, ok := convertInterfaceToMap(val)
 		if !ok {
-			return nil, errWhereInType
+			errMsg := fmt.Sprintf(errWhereInterfaceSliceType, op)
+			return nil, errors.New(errMsg)
 		}
 		if 0 == len(vals) {
-			return nil, errEmptyINCondition
+			errMsg := fmt.Sprintf(errEmptySliceCondition, op)
+			return nil, errors.New(errMsg)
 		}
 		result[key] = vals
 	}
@@ -395,7 +398,7 @@ func removeInnerSpace(operator string) string {
 		return operator
 	}
 	lastSpace := firstSpace
-	for i := firstSpace+1; i<n; i++ {
+	for i := firstSpace + 1; i < n; i++ {
 		if operator[i] == ' ' {
 			lastSpace = i
 		} else {

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -349,12 +349,10 @@ func convertWhereMapToWhereMapSlice(where map[string]interface{}, op string) (ma
 	for key, val := range where {
 		vals, ok := convertInterfaceToMap(val)
 		if !ok {
-			errMsg := fmt.Sprintf(errWhereInterfaceSliceType, op)
-			return nil, errors.New(errMsg)
+			return nil, fmt.Errorf(errWhereInterfaceSliceType, op)
 		}
 		if 0 == len(vals) {
-			errMsg := fmt.Sprintf(errEmptySliceCondition, op)
-			return nil, errors.New(errMsg)
+			return nil, fmt.Errorf(errEmptySliceCondition, op)
 		}
 		result[key] = vals
 	}

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -836,11 +836,12 @@ func Test_NotIn(t *testing.T) {
 	}
 	table := "some_table"
 	selectFields := []string{"name", "age", "sex"}
-	cond, _, err := BuildSelect(table, where, selectFields)
+	cond, vals, err := BuildSelect(table, where, selectFields)
 	ass := assert.New(t)
 	ass.NoError(err)
 	expect := `SELECT name,age,sex FROM some_table WHERE (city IN (?,?) AND hobbies NOT IN (?,?,?) AND age>? AND address IS NOT NULL) GROUP BY department ORDER BY bonus DESC`
 	ass.Equal(expect, cond)
+	ass.Equal([]interface{}{"beijing", "shanghai", "baseball", "swim", "running", 35}, vals)
 }
 
 func TestBuildBetween(t *testing.T) {

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -51,7 +51,7 @@ func TestBuildHaving(t *testing.T) {
 			},
 			out: outStruct{
 				cond: "SELECT name, count(price) as total FROM tb WHERE (age>?) GROUP BY name HAVING (total>=? AND total<?)",
-				vals: []interface{}{23,  1000, 50000},
+				vals: []interface{}{23, 1000, 50000},
 				err:  nil,
 			},
 		},
@@ -329,7 +329,7 @@ func Test_BuildSelect(t *testing.T) {
 
 func BenchmarkBuildSelect_Sequelization(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		_,_,err := BuildSelect("tb", map[string]interface{}{
+		_, _, err := BuildSelect("tb", map[string]interface{}{
 			"foo":      "bar",
 			"qq":       "tt",
 			"age in":   []interface{}{1, 3, 5, 7, 9},
@@ -601,7 +601,7 @@ func Benchmark_BuildIN(b *testing.B) {
 		"age": []uint64{1, 3, 5, 7, 9},
 	}
 	for i := 0; i < b.N; i++ {
-		convertWhereMapToWhereMapSlice(where)
+		convertWhereMapToWhereMapSlice(where, opIn)
 	}
 }
 
@@ -903,7 +903,7 @@ func TestNotLike(t *testing.T) {
 func TestNotLike_1(t *testing.T) {
 	where := map[string]interface{}{
 		"name  not like  ": "%ny",
-		"age": 20,
+		"age":              20,
 	}
 	cond, vals, err := BuildSelect("tb", where, nil)
 	ass := assert.New(t)


### PR DESCRIPTION
* fix bug: show different error message for `in`, `not in`, `between`, `not between` ops.
* enhancement: compare vals in `Test_NotIn` testcase.
* enhancement: reformat code.