### PR TITLE
enhance #74: builder relax the syntax restriction of orderby operator

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -76,7 +76,7 @@ func main() {
 
 sign: `BuildSelect(table string, where map[string]interface{}, field []string) (string,[]interface{},error)`
 
-operators supported:
+operators supported(case-insensitive):
 
 * =
 * &gt;

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -13,6 +13,7 @@ var (
 	// ErrUnsupportedOperator reports there's unsupported operators in where-condition
 	ErrUnsupportedOperator       = errors.New("[builder] unsupported operator")
 	errOrValueType               = errors.New(`[builder] the value of "_or" must be of slice of map[string]interface{} type`)
+	errOrderByValueType          = errors.New(`[builder] the value of "_orderby" must be of string type`)
 	errGroupByValueType          = errors.New(`[builder] the value of "_groupby" must be of string type`)
 	errLimitValueType            = errors.New(`[builder] the value of "_limit" must be of []uint type`)
 	errLimitValueLength          = errors.New(`[builder] the value of "_limit" must contain one or two uint elements`)
@@ -59,7 +60,7 @@ func BuildSelect(table string, where map[string]interface{}, selectField []strin
 	if val, ok := copiedWhere["_orderby"]; ok {
 		s, ok := val.(string)
 		if !ok {
-			err = errGroupByValueType
+			err = errOrderByValueType
 			return
 		}
 		orderBy = strings.TrimSpace(s)

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -146,7 +146,7 @@ func resolveHaving(having interface{}) (map[string]interface{}, error) {
 		if nil != err {
 			return nil, err
 		}
-		if !isStringInSlice(operator, opOrder) {
+		if !isStringInSlice(strings.ToLower(operator), opOrder) {
 			return nil, errHavingUnsupportedOperator
 		}
 		copiedMap[key] = val
@@ -228,11 +228,12 @@ func getWhereConditions(where map[string]interface{}) ([]Comparable, error) {
 			continue
 		}
 		field, operator, err = splitKey(key)
-		if !isStringInSlice(operator, opOrder) {
-			return nil, ErrUnsupportedOperator
-		}
 		if nil != err {
 			return nil, err
+		}
+		operator = strings.ToLower(operator)
+		if !isStringInSlice(operator, opOrder) {
+			return nil, ErrUnsupportedOperator
 		}
 		if _, ok := val.(NullType); ok {
 			operator = opNull

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -121,6 +121,25 @@ func TestBuildHaving(t *testing.T) {
 				err:  nil,
 			},
 		},
+		{
+			in: inStruct{
+				table: "tb",
+				where: map[string]interface{}{
+					"_groupby": "  ",
+					"_having": map[string]interface{}{
+						"total >=": 1000,
+						"total <":  50000,
+					},
+					"age in": []interface{}{1, 2, 3},
+				},
+				selectField: []string{"name, age"},
+			},
+			out: outStruct{
+				cond: "SELECT name, age FROM tb WHERE (age IN (?,?,?))",
+				vals: []interface{}{1, 2, 3},
+				err:  nil,
+			},
+		},
 	}
 	ass := assert.New(t)
 	for _, tc := range data {
@@ -369,7 +388,7 @@ func Test_BuildSelect(t *testing.T) {
 							},
 						},
 					},
-					"_orderby": "age desc, score asc",
+					"_orderby": "age DESC,score ASC",
 					"_groupby": "department",
 					"_limit":   []uint{0, 100},
 				},
@@ -409,6 +428,21 @@ func Test_BuildSelect(t *testing.T) {
 				err:  nil,
 			},
 		},
+		{
+			in: inStruct{
+				table: "tb",
+				where: map[string]interface{}{
+					"foo":      "bar",
+					"_orderby": "  ",
+				},
+				fields: nil,
+			},
+			out: outStruct{
+				cond: "SELECT * FROM tb WHERE (foo=?)",
+				vals: []interface{}{"bar"},
+				err:  nil,
+			},
+		},
 	}
 	ass := assert.New(t)
 	for _, tc := range data {
@@ -426,7 +460,7 @@ func BenchmarkBuildSelect_Sequelization(b *testing.B) {
 			"qq":       "tt",
 			"age in":   []interface{}{1, 3, 5, 7, 9},
 			"faith <>": "Muslim",
-			"_orderby": "age desc",
+			"_orderby": "age DESC",
 			"_groupby": "department",
 			"_limit":   []uint{0, 100},
 		}, []string{"a", "b", "c"})
@@ -445,7 +479,7 @@ func BenchmarkBuildSelect_Parallel(b *testing.B) {
 				"qq":       "tt",
 				"age in":   []interface{}{1, 3, 5, 7, 9},
 				"faith <>": "Muslim",
-				"_orderby": "age desc",
+				"_orderby": "age DESC",
 				"_groupby": "department",
 				"_limit":   []uint{0, 100},
 			}, nil)
@@ -595,7 +629,7 @@ func Test_BuildIN(t *testing.T) {
 					"qq":       "tt",
 					"age in":   []int{1, 3, 5, 7, 9},
 					"faith <>": "Muslim",
-					"_orderby": "age desc",
+					"_orderby": "age DESC",
 					"_groupby": "department",
 				},
 				fields: []string{"id", "name", "age"},
@@ -660,7 +694,7 @@ func Test_BuildOrderBy(t *testing.T) {
 				table: "tb",
 				where: map[string]interface{}{
 					"foo":      "bar",
-					"_orderby": "age desc, id asc",
+					"_orderby": "age DESC,id ASC",
 				},
 				fields: []string{"id", "name", "age"},
 			},
@@ -675,42 +709,12 @@ func Test_BuildOrderBy(t *testing.T) {
 				table: "tb",
 				where: map[string]interface{}{
 					"foo":      "bar",
-					"_orderby": "   age    desc,id     asc    ",
+					"_orderby": "RAND()",
 				},
 				fields: []string{"id", "name", "age"},
 			},
 			out: outStruct{
-				cond: "SELECT id,name,age FROM tb WHERE (foo=?) ORDER BY age DESC,id ASC",
-				vals: []interface{}{"bar"},
-				err:  nil,
-			},
-		},
-		{
-			in: inStruct{
-				table: "tb",
-				where: map[string]interface{}{
-					"foo":      "bar",
-					"_orderby": "   age    desc,   id     asc    ",
-				},
-				fields: []string{"id", "name", "age"},
-			},
-			out: outStruct{
-				cond: "SELECT id,name,age FROM tb WHERE (foo=?) ORDER BY age DESC,id ASC",
-				vals: []interface{}{"bar"},
-				err:  nil,
-			},
-		},
-		{
-			in: inStruct{
-				table: "tb",
-				where: map[string]interface{}{
-					"foo":      "bar",
-					"_orderby": "   age    desc",
-				},
-				fields: []string{"id", "name", "age"},
-			},
-			out: outStruct{
-				cond: "SELECT id,name,age FROM tb WHERE (foo=?) ORDER BY age DESC",
+				cond: "SELECT id,name,age FROM tb WHERE (foo=?) ORDER BY RAND()",
 				vals: []interface{}{"bar"},
 				err:  nil,
 			},
@@ -870,7 +874,7 @@ func Test_NotIn(t *testing.T) {
 			"address":            IsNotNull,
 			" hobbies not in   ": []string{"baseball", "swim", "running"},
 			"_groupby":           "department",
-			"_orderby":           "bonus desc",
+			"_orderby":           "bonus DESC",
 		},
 		{
 			"city IN":            []string{"beijing", "shanghai"},
@@ -878,7 +882,7 @@ func Test_NotIn(t *testing.T) {
 			"address":            IsNotNull,
 			" hobbies NOT IN   ": []string{"baseball", "swim", "running"},
 			"_groupby":           "department",
-			"_orderby":           "bonus desc",
+			"_orderby":           "bonus DESC",
 		},
 	}
 

--- a/builder/dao_test.go
+++ b/builder/dao_test.go
@@ -111,25 +111,6 @@ func TestAssembleExpression(t *testing.T) {
 	}
 }
 
-func TestOrderBy(t *testing.T) {
-	var data = []struct {
-		inOrderBy []eleOrderBy
-		outStr    string
-		outErr    error
-	}{
-		{[]eleOrderBy{eleOrderBy{"age", "desc"}}, "age DESC", nil},
-		{[]eleOrderBy{eleOrderBy{"name", "Asc"}}, "name ASC", nil},
-		{[]eleOrderBy{eleOrderBy{"tt", "DesC"}}, "tt DESC", nil},
-		{[]eleOrderBy{eleOrderBy{"qq", "DESCC"}}, "", errOrderByParam},
-	}
-	ass := assert.New(t)
-	for _, tc := range data {
-		actual, err := orderBy(tc.inOrderBy)
-		ass.Equal(tc.outErr, err)
-		ass.Equal(tc.outStr, actual)
-	}
-}
-
 func TestResolveKV(t *testing.T) {
 	var data = []struct {
 		in      map[string]interface{}
@@ -348,7 +329,7 @@ func TestBuildSelect(t *testing.T) {
 		fields     []string
 		conditions []Comparable
 		groupBy    string
-		orderBy    []eleOrderBy
+		orderBy    string
 		limit      *eleLimit
 		outStr     string
 		outVals    []interface{}
@@ -385,7 +366,7 @@ func TestBuildSelect(t *testing.T) {
 				}),
 			},
 			groupBy: "",
-			orderBy: []eleOrderBy{eleOrderBy{field: "foo", order: "desc"}, {"baz", "aSc"}},
+			orderBy: "foo DESC,baz ASC",
 			limit: &eleLimit{
 				begin: 10,
 				step:  20,


### PR DESCRIPTION
* Enhance issue #74.
* Remove the leading and trailing white space of `_orderby` and `_groupby` value. Otherwise, builder would take a string full of spaces as a valid value.

For example: 
```go
cond, vals, err := builder.BuildSelect(
     "foo",
     map[string]interface{}{
          "_groupby": "  ",
          "_having": map[string]interface{}{
               "total >=": 1000,
          },
     },
     []string{
	"bar",
     },
)
```

the cond would be:
```sql
SELECT bar FROM foo GROUP BY    HAVING (total>=?)
```