### PR TITLE
improve `scanner.Map`'s performance by caching resolved tags

### DIFF
--- a/scanner/README.md
+++ b/scanner/README.md
@@ -49,14 +49,17 @@ ScanMapClose is the same as ScanMap but it also close the rows
 Test cases blow may make sense
 
 ```go
-package scaner
+package scaner_test
 
 import (
+	"github.com/didi/gendry/scanner"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestMap(t *testing.T) {
+	// you can improve the performance of `scanner.Map` by scanner.EnableMapNameCache(true)
+	scanner.EnableMapNameCache(true)
 	type Person struct {
 		Name string `ddb:"name"`
 		Age  int    `ddb:"age"`
@@ -65,14 +68,14 @@ func TestMap(t *testing.T) {
 	a := Person{"deen", 22, 1}
 	b := &Person{"caibirdme", 23, 1}
 	c := &b
-	mapA, err := Map(a, DefaultTagName)
+	mapA, err := scanner.Map(a, scanner.DefaultTagName)
 	ass := assert.New(t)
 	ass.NoError(err)
 	ass.Equal("deen", mapA["name"])
 	ass.Equal(22, mapA["age"])
 	_, ok := mapA["foo"]
 	ass.False(ok)
-	mapB, err := Map(c, "")
+	mapB, err := scanner.Map(c, "")
 	ass.NoError(err)
 	ass.Equal("caibirdme", mapB["Name"])
 	ass.Equal(23, mapB["Age"])

--- a/scanner/map.go
+++ b/scanner/map.go
@@ -4,12 +4,24 @@ import (
 	"errors"
 	"reflect"
 	"strings"
+	"sync"
 )
 
 var (
 	// ErrNoneStructTarget as its name says
 	ErrNoneStructTarget = errors.New("[scanner] target must be a struct type")
+
+	enableMapNameCache bool
+
+	nameCache = &keyNameCache{
+		nameMap: make(map[reflect.Type]map[string][]string),
+	}
 )
+
+// EnableMapNameCache improve performance by caching resolved key names
+func EnableMapNameCache(isEnable bool) {
+	enableMapNameCache = isEnable
+}
 
 // Map converts a struct to a map
 // type for each field of the struct must be built-in type
@@ -26,8 +38,21 @@ func Map(target interface{}, useTag string) (map[string]interface{}, error) {
 	}
 	t := v.Type()
 	result := make(map[string]interface{})
+
+	var getKeyName func(int) string
+	if enableMapNameCache {
+		names := nameCache.GetKeyNames(t, useTag)
+		getKeyName = func(i int) string {
+			return names[i]
+		}
+	} else {
+		getKeyName = func(i int) string {
+			return getKey(t.Field(i), useTag)
+		}
+	}
+
 	for i := 0; i < t.NumField(); i++ {
-		keyName := getKey(t.Field(i), useTag)
+		keyName := getKeyName(i)
 		if "" == keyName {
 			continue
 		}
@@ -63,4 +88,44 @@ func resolveTagName(tag string) string {
 		return tag
 	}
 	return tag[:idx]
+}
+
+type keyNameCache struct {
+	mutex sync.Mutex
+
+	// nameMap: type of struct -> map(tag -> resolved key names of the struct, array indexed by field index)
+	nameMap map[reflect.Type]map[string][]string
+}
+
+func (cache *keyNameCache) GetKeyNames(t reflect.Type, useTag string) []string {
+	names := cache.nameMap[t][useTag]
+	if names != nil {
+		return names
+	}
+	cache.mutex.Lock()
+	defer cache.mutex.Unlock()
+	// double check
+	names = cache.nameMap[t][useTag]
+	if names != nil {
+		return names
+	}
+	// resolve names then set to cache
+	names = cache.resolveKeyNamesOf(t, useTag)
+	if m, ok := cache.nameMap[t]; ok {
+		m[useTag] = names
+	} else {
+		m = make(map[string][]string)
+		cache.nameMap[t] = m
+		m[useTag] = names
+	}
+	return names
+}
+
+func (cache *keyNameCache) resolveKeyNamesOf(t reflect.Type, useTag string) []string {
+	result := make([]string, t.NumField())
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+		result[i] = getKey(field, useTag)
+	}
+	return result
 }

--- a/scanner/map_bench_test.go
+++ b/scanner/map_bench_test.go
@@ -1,0 +1,27 @@
+package scanner
+
+import (
+	"testing"
+)
+
+var p = 12
+var a = person{"deen", 22, 1, &p}
+
+// go test -run=BenchmarkMap -bench=BenchmarkMap -cpu=1,2,4,8 -benchtime=20000000x -benchmem
+func BenchmarkMapWithCache(b *testing.B) {
+	EnableMapNameCache(true)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = Map(&a, DefaultTagName)
+		}
+	})
+}
+
+func BenchmarkMapDisableCache(b *testing.B) {
+	EnableMapNameCache(false)
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			_, _ = Map(&a, DefaultTagName)
+		}
+	})
+}


### PR DESCRIPTION
`scanner.Map`方法通过反射获取key name，开销较大，这里通过缓存结构体的key name解析结果来提升性能。

具体表现如下，通过使用缓存可以将`scanner.Map`接口的吞吐提升1-2倍。

```
$ go test -run=BenchmarkMap -bench=BenchmarkMap -cpu=1,2,4,8 -benchtime=20000000x -benchmem
goos: darwin
goarch: amd64
pkg: github.com/didi/gendry/scanner
cpu: Intel(R) Core(TM) i7-9750H CPU @ 2.60GHz
BenchmarkMapWithCache           20000000               265.4 ns/op           360 B/op          4 allocs/op
BenchmarkMapWithCache-2         20000000               152.2 ns/op           360 B/op          4 allocs/op
BenchmarkMapWithCache-4         20000000                88.22 ns/op          360 B/op          4 allocs/op
BenchmarkMapWithCache-8         20000000                70.87 ns/op          360 B/op          4 allocs/op
BenchmarkMapDisableCache        20000000               695.3 ns/op           400 B/op          9 allocs/op
BenchmarkMapDisableCache-2      20000000               348.7 ns/op           400 B/op          9 allocs/op
BenchmarkMapDisableCache-4      20000000               195.2 ns/op           400 B/op          9 allocs/op
BenchmarkMapDisableCache-8      20000000               169.8 ns/op           400 B/op          9 allocs/op
PASS
ok      github.com/didi/gendry/scanner  39.892s
```