### PR TITLE
support fields linked with ops

### DIFF
--- a/builder/builder.go
+++ b/builder/builder.go
@@ -423,8 +423,7 @@ func splitKey(key string, val interface{}) (field string, operator string, err e
 	}
 	idx := strings.IndexByte(key, ' ')
 	if idx == -1 {
-		field = key
-		operator = "="
+		field, operator = splitKeyNoSpace(key)
 		if reflect.ValueOf(val).Kind() == reflect.Slice {
 			operator = "in"
 		}
@@ -432,6 +431,23 @@ func splitKey(key string, val interface{}) (field string, operator string, err e
 		field = key[:idx]
 		operator = strings.Trim(key[idx+1:], " ")
 		operator = removeInnerSpace(operator)
+	}
+	return
+}
+
+var opCanLinkedWithField = []string{opNe1, opNe2, opGte, opLte, opEq, opGt, opLt} // 2 chars op first
+
+func splitKeyNoSpace(key string) (field string, operator string) {
+	field = key
+	operator = "="
+	for _, op := range opCanLinkedWithField {
+		idx := strings.Index(key, op)
+		if idx != -1 {
+			field = key[:idx]
+			operator = key[idx:]
+			break
+		}
+		continue
 	}
 	return
 }

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -598,6 +598,35 @@ func Test_BuildSelect(t *testing.T) {
 				err:  nil,
 			},
 		},
+		{
+			in: inStruct{
+				table: "tb",
+				where: map[string]interface{}{
+					"foo":      "bar",
+					"foo1>=":   "bar",
+					"foo2<=":   "bar",
+					"foo3<>":   "bar",
+					"foo4!=":   "bar",
+					"foo5>":    "bar",
+					"foo6<":    "bar",
+					"foo7=":    "bar",
+					"foo11 >=": "bar",
+					"foo12 <=": "bar",
+					"foo13 <>": "bar",
+					"foo14 !=": "bar",
+					"foo15 >":  "bar",
+					"foo16 <":  "bar",
+					"foo17 =":  "bar",
+					"_orderby": "  ",
+				},
+				fields: nil,
+			},
+			out: outStruct{
+				cond: "SELECT * FROM tb WHERE (foo=? AND foo17=? AND foo7=? AND foo14!=? AND foo4!=? AND foo13!=? AND foo3!=? AND foo15>? AND foo5>? AND foo1>=? AND foo11>=? AND foo16<? AND foo6<? AND foo12<=? AND foo2<=?)",
+				vals: []interface{}{"bar", "bar", "bar", "bar", "bar", "bar", "bar", "bar", "bar", "bar", "bar", "bar", "bar", "bar", "bar"},
+				err:  nil,
+			},
+		},
 	}
 	ass := assert.New(t)
 	for _, tc := range data {


### PR DESCRIPTION
```golang
builder.BuildSelect(map[string]interface{}{
    "foo>": "bar"
})
```
got
```sql
SELECT * FROM tb WHERE (foo>=?)"
```

when no space in `key`, not default `field=key` and `operator="="`, but try to parse `fileds linked with ops`, such as `foo>`,`foo>=`,`foo<`,`foo<=`,`foo<>`,`foo!=`,`foo=`