### PR TITLE
支持对scan后rows.Err()检查

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -32,6 +32,8 @@ type Rows interface {
 	Next() bool
 
 	Scan(dest ...interface{}) error
+
+	Err() error
 }
 
 const (
@@ -328,6 +330,10 @@ func resolveDataFromRows(rows Rows) ([]map[string]interface{}, error) {
 			mp[name] = *(values[idx].(*interface{}))
 		}
 		result = append(result, mp)
+	}
+	err = rows.Err()
+	if nil != err {
+		return nil, err
 	}
 	return result, nil
 }


### PR DESCRIPTION
ctx超时或取消情况下，scanner.Scan()方法会把err吞掉，不返回err，导致读出的数据不全