### PR TITLE
fix bug: manager settings set blank value option missing

### DIFF
--- a/manager/database.go
+++ b/manager/database.go
@@ -24,14 +24,14 @@ func boolSetting(source, param string, ok bool) string {
 func timeSetting(source, param string, t time.Duration) string {
 	//make sure 1ms<=t<24h
 	if t < time.Millisecond || t >= 24*time.Hour {
-		return ""
+		return source
 	}
 	return fmt.Sprintf(cDSNFormat, source, param, t)
 }
 
 func stringSetting(source, param, value string) string {
 	if "" == value {
-		return ""
+		return source
 	}
 	return fmt.Sprintf(cDSNFormat, source, param, value)
 }

--- a/manager/database_test.go
+++ b/manager/database_test.go
@@ -48,14 +48,16 @@ func TestConcatDSN_Time(t *testing.T) {
 func TestConcatDSN_Time_overflow(t *testing.T) {
 	var setting []Setting
 	ass := assert.New(t)
-	setting = append(setting, SetReadTimeout(time.Microsecond), SetTimeout(24*time.Hour))
-	ass.Equal("", concatDSN(setting), "duration <1ms or >=24h should be invalid")
+	setting = append(setting, SetWriteTimeout(time.Minute), SetReadTimeout(time.Microsecond), SetTimeout(24*time.Hour))
+	ass.Equal("writeTimeout=1m0s", concatDSN(setting), "duration <1ms or >=24h should be invalid")
 }
 
 func TestConcatDSN_String_null(t *testing.T) {
 	var setting []Setting
 	ass := assert.New(t)
 	setting = append(setting, SetCollation(""), SetLoc(""), SetStrict(false), SetInterpolateParams(true))
+	ass.Equal("strict=false&interpolateParams=true", concatDSN(setting), `null value should be ignored`)
+	setting = append(setting, SetCollation(""), SetStrict(false), SetInterpolateParams(true), SetLoc(""))
 	ass.Equal("strict=false&interpolateParams=true", concatDSN(setting), `null value should be ignored`)
 }
 

--- a/manager/database_test.go
+++ b/manager/database_test.go
@@ -55,9 +55,9 @@ func TestConcatDSN_Time_overflow(t *testing.T) {
 func TestConcatDSN_String_null(t *testing.T) {
 	var setting []Setting
 	ass := assert.New(t)
-	setting = append(setting, SetCollation(""), SetLoc(""), SetStrict(false), SetInterpolateParams(true))
+	setting = append([]Setting{}, SetCollation(""), SetLoc(""), SetStrict(false), SetInterpolateParams(true))
 	ass.Equal("strict=false&interpolateParams=true", concatDSN(setting), `null value should be ignored`)
-	setting = append(setting, SetCollation(""), SetStrict(false), SetInterpolateParams(true), SetLoc(""))
+	setting = append([]Setting{}, SetCollation(""), SetStrict(false), SetInterpolateParams(true), SetLoc(""))
 	ass.Equal("strict=false&interpolateParams=true", concatDSN(setting), `null value should be ignored`)
 }
 


### PR DESCRIPTION
```
db, err = manager.New(conf.Dbname, conf.User, conf.Password, conf.Host).Driver(driver).Set(
    manager.SetParseTime(true),
    manager.SetLoc(url.QueryEscape("Asia/Shanghai")),
    manager.SetCharset(conf.Charset),
    manager.SetTimeout(conf.ConnectTimeout),
    manager.SetReadTimeout(conf.ReadTimeout),
    manager.SetWriteTimeout(conf.WriteTimeout),
    manager.SetInterpolateParams(conf.InterpolateParams)).Port(conf.Port).Open(true)
```

配置 charset=utf8 时的 dsn
```
TEST_DB:123456@tcp(127.0.0.1:3306)/TEST_DB?parseTime=true&loc=Asia%2FShanghai&charset=utf8&timeout=5s&readTimeout=5s&writeTimeout=5s&interpolateParams=false
```

不配置 charset=utf8 时的 dsn
```
TEST_DB:123456@tcp(127.0.0.1:3306)/TEST_DB?timeout=5s&readTimeout=5s&writeTimeout=5s&interpolateParams=false
```