### PR TITLE
builder where & update support Raw SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,20 @@ cond, values, err := builder.BuildSelect(table, where, selectFields)
 //values = []interface{}{11, 45, "234", "tx2", 5, "beijing", "shanghai", 35}
 
 rows, err := db.Query(cond, values...)
+
+
+// support builder.Raw in where & update
+where := map[string]interface{}{"gmt_create <": builder.Raw("gmt_modified")}
+cond, values, err := builder.BuildSelect(table, where, selectFields)
+// SELECT * FROM x WHERE gmt_create < gmt_modified
+
+update = map[string]interface{}{
+    "code": builder.Raw("VALUES(code)"), // mysql 8.x  builder.Raw("new.code")
+    "name": builder.Raw("VALUES(name)"), // mysql 8.x  builder.Raw("new.name")
+}
+cond, values, err := builder.BuildInsertOnDuplicate(table, data, update)
+// INSERT INTO country (id, code, name) VALUES (?,?,?),(?,?,?),(?,?,?) 
+// ON DUPLICATE KEY UPDATE code=VALUES(code),name=VALUES(name)
 ```
 
 In the `where` param, `in` operator is automatically added by value type(reflect.Slice).

--- a/builder/builder.go
+++ b/builder/builder.go
@@ -35,6 +35,8 @@ var (
 	}
 )
 
+type Raw string
+
 type whereMapSet struct {
 	set map[string]map[string]interface{}
 }

--- a/builder/builder_test.go
+++ b/builder/builder_test.go
@@ -608,7 +608,7 @@ func Test_BuildSelect(t *testing.T) {
 	}
 }
 
-func Test_BuildSelectMutliOr(t *testing.T) {
+func Test_BuildSelectMultiOr(t *testing.T) {
 	type inStruct struct {
 		table  string
 		where  map[string]interface{}

--- a/builder/dao.go
+++ b/builder/dao.go
@@ -413,9 +413,6 @@ func resolveUpdate(update map[string]interface{}) (sets string, vals []interface
 	for _, k := range keys {
 		v := update[k]
 		if _, ok := v.(Raw); ok {
-			if v == Raw("") {
-				v = fmt.Sprintf("VALUES(%s)", k)
-			}
 			sb.WriteString(fmt.Sprintf("%s=%s,", k, v))
 			continue
 		}

--- a/builder/dao.go
+++ b/builder/dao.go
@@ -405,6 +405,9 @@ func buildInsertOnDuplicate(table string, data []map[string]interface{}, update 
 
 func resolveUpdate(update map[string]interface{}) (sets string, vals []interface{}) {
 	keys := make([]string, 0, len(update))
+	for key := range update {
+		keys = append(keys, key)
+	}
 	defaultSortAlgorithm(keys)
 	var sb strings.Builder
 	for _, k := range keys {
@@ -417,7 +420,7 @@ func resolveUpdate(update map[string]interface{}) (sets string, vals []interface
 			continue
 		}
 		vals = append(vals, v)
-		sets += fmt.Sprintf("%s=?,", quoteField(k))
+		sb.WriteString(fmt.Sprintf("%s=?,", quoteField(k)))
 	}
 	sets = strings.TrimRight(sb.String(), ",")
 	return sets, vals

--- a/builder/dao_test.go
+++ b/builder/dao_test.go
@@ -118,7 +118,7 @@ func TestResolveUpdate(t *testing.T) {
 		outVals []interface{}
 	}{
 		{
-			map[string]interface{}{
+			in: map[string]interface{}{
 				"foo": "bar",
 				"bar": 1,
 			},
@@ -126,13 +126,13 @@ func TestResolveUpdate(t *testing.T) {
 			outVals: []interface{}{1, "bar"},
 		},
 		{
-			map[string]interface{}{
+			in: map[string]interface{}{
 				"qq":    "ttt",
 				"some":  123,
 				"other": 456,
 			},
 			outStr:  "other=?,qq=?,some=?",
-			[]interface{}{456, "ttt", 123},
+			outVals: []interface{}{456, "ttt", 123},
 		},
 		{
 			in: map[string]interface{}{ // mysql5.7

--- a/builder/dao_test.go
+++ b/builder/dao_test.go
@@ -135,7 +135,7 @@ func TestResolveUpdate(t *testing.T) {
 			[]interface{}{456, "ttt", 123},
 		},
 		{
-			in: map[string]any{ // mysql5.7
+			in: map[string]interface{}{ // mysql5.7
 				"id":   1,
 				"name": Raw(""),
 				"age":  Raw("VALUES(age)"),
@@ -144,7 +144,7 @@ func TestResolveUpdate(t *testing.T) {
 			outVals: []interface{}{1},
 		},
 		{
-			in: map[string]any{ // mysql8.0
+			in: map[string]interface{}{ // mysql8.0
 				"id":   1,
 				"name": Raw("new.name"),
 				"age":  Raw("new.age"),

--- a/builder/dao_test.go
+++ b/builder/dao_test.go
@@ -137,7 +137,7 @@ func TestResolveUpdate(t *testing.T) {
 		{
 			in: map[string]interface{}{ // mysql5.7
 				"id":   1,
-				"name": Raw(""),
+				"name": Raw("VALUES(name)"),
 				"age":  Raw("VALUES(age)"),
 			},
 			outStr:  "age=VALUES(age),id=?,name=VALUES(name)",


### PR DESCRIPTION
related issues https://github.com/didi/gendry/issues/141  https://github.com/didi/gendry/issues/122

builder supports such as
```
update = map[string]interface{}{
    "code": builder.Raw("VALUES(code)"), // mysql 8.x  builder.Raw("new.code")
    "name": builder.Raw("VALUES(name)"), // mysql 8.x  builder.Raw("new.name")
}

// INSERT INTO country (id, code, name) VALUES (?,?,?),(?,?,?),(?,?,?) 
// ON DUPLICATE KEY UPDATE code=VALUES(code),name=VALUES(name)
```

```
where := map[string]interface{}{"gmt_create <": builder.Raw("gmt_modified")}
// SELECT * FROM x 
// WHERE gmt_create < gmt_modified
```